### PR TITLE
Revert back to passing widget options on to the terria object

### DIFF
--- a/Source/CesiumNavigation.js
+++ b/Source/CesiumNavigation.js
@@ -88,7 +88,7 @@ function initialize(viewerCesiumWidget, options = { units: 'kilometers' }) {
   cesiumWidget.container.appendChild(container);
 
   this.terria = viewerCesiumWidget;
-  this.terria.options = defined(options);
+  this.terria.options = defined(options) ? options : {};
   this.terria.afterWidgetChanged = new Event();
   this.terria.beforeWidgetChanged = new Event();
   this.container = container;


### PR DESCRIPTION
fixes broken [defaultResetView](https://github.com/nmccready/cesium-navigation/blob/17b4cc22f28e2134cec3e4272c280a606217803f/Source/ViewModels/ResetViewNavigationControl.js#L81) and maybe some other stuff