### PR TITLE
Using Object.defineProperties instead of Cesium's deprecated defineProperties function

### DIFF
--- a/Source/ViewModels/UserInterfaceControl.js
+++ b/Source/ViewModels/UserInterfaceControl.js
@@ -1,4 +1,4 @@
-import { defined, defineProperties, DeveloperError } from 'cesium';
+import { defined, DeveloperError } from 'cesium';
 import Knockout from 'knockout-es5';
 
 /**
@@ -72,7 +72,7 @@ export default function UserInterfaceControl(terria) {
   ]);
 }
 
-defineProperties(UserInterfaceControl.prototype, {
+Object.defineProperties(UserInterfaceControl.prototype, {
   /**
    * Gets the Terria instance.
    * @memberOf UserInterfaceControl.prototype

--- a/Source/viewerCesiumNavigationMixin.js
+++ b/Source/viewerCesiumNavigationMixin.js
@@ -1,4 +1,4 @@
-import { defined, defineProperties, DeveloperError } from 'cesium';
+import { defined, DeveloperError } from 'cesium';
 import CesiumNavigation from './CesiumNavigation';
 import './Styles/cesium-navigation.less';
 /**
@@ -36,7 +36,7 @@ function viewerCesiumNavigationMixin(viewer, options) {
     })(viewer)
   );
 
-  defineProperties(viewer, {
+  Object.defineProperties(viewer, {
     cesiumNavigation: {
       configurable: true,
       get: () => viewer.cesiumWidget.cesiumNavigation
@@ -62,7 +62,7 @@ const init = function(viewerCesiumWidget, options) {
     ? viewerCesiumWidget.cesiumWidget
     : viewerCesiumWidget;
 
-  defineProperties(cesiumWidget, {
+  Object.defineProperties(cesiumWidget, {
     cesiumNavigation: {
       configurable: true,
       get: () => cesiumNavigation


### PR DESCRIPTION
defineProperties is no longer exported by Cesium

See: https://github.com/CesiumGS/cesium/pull/8633